### PR TITLE
Update cjs.rst

### DIFF
--- a/docs/cjs.rst
+++ b/docs/cjs.rst
@@ -76,7 +76,7 @@ Using hashmaps vs properties
 
 Using ``this.smallobject['property']`` is faster than ``this.smallobject.property``.
 
-The idea is confirmed by https://jsperf.com/dot-notation-vs-square-bracket-notation.
+The idea is confirmed by https://www.freecodecamp.org/news/dot-notation-vs-square-brackets-javascript/.
 
 So instead of using:
 


### PR DESCRIPTION
JSperf doesn't appear to exist anymore, so the link wasn't working. I'd like to suggest this other article from FCC that I believe shares the same info.